### PR TITLE
Update core.py label_str reference

### DIFF
--- a/autoremoveplus/core.py
+++ b/autoremoveplus/core.py
@@ -548,6 +548,7 @@ class Core(CorePluginBase):
                             log.warning("Torrent: {}, label = {}".format(name,label_str))
                     except Exception as e:
                         log.error("Error getting label for torrent {}: {}".format(name,e))
+                        label_str = 'none'
                     log.debug("Processing unfinished torrent {}, label = {}".format(name,label_str))
                     if remove_cond:
                         #user has selected to remove torrents


### PR DESCRIPTION
There is a reference before assignment for any item that does not have a label attached. Adding an assignment to the exception fixes this issue since it is referenced later.